### PR TITLE
added similar scripts for export policies and rules for nfs

### DIFF
--- a/backupExportPolicyRules.ps1
+++ b/backupExportPolicyRules.ps1
@@ -1,0 +1,71 @@
+# Usage:
+# Run as: .\backupExportPolicyRules.ps1 -server <mgmt_ip> -user <mgmt_user> -password <mgmt_user_password> -vserver <vserver name> -exportPolicyFile <xml file to store export policies> -exportRuleFile <xml file to store export policy rules> -spit <none,less,more depending on info to print>
+#
+# Example
+# 1. If you want to save exports on vserver vs2 and display more output
+# Run as: .\backupExportPolicyRules.ps1 -server 10.53.33.59 -user admin -password netapp1! -vserver vs2 -exportPolicyFile C:\export.xml -exportRuleFile C:\rules.xml -spit more 
+#
+# 2. If you want to save exports to a csv file for examination
+# Run as: .\backupExportPolicyRules.ps1 -s 10.53.33.59 -u admin -p netapp1! -v vs2 -ep C:\share.csv -er C:\rules.csv -spit more -csv true
+
+Param([parameter(Mandatory = $true)] [alias("s")] $server,
+      [parameter(Mandatory = $true)] [alias("u")] $user,
+      [parameter(Mandatory = $true)] [alias("p")] $password,
+      [parameter(Mandatory = $true)] [alias("v")] $vserver,
+      [parameter(Mandatory = $true)] [alias("ep")] $exportPolicyFile,
+      [parameter(Mandatory = $true)] [alias("er")] $exportRuleFile,
+      [parameter(Mandatory = $true)] [alias("sp")] [Validateset("none","less","more")] $spit,
+      [Validateset("false","true")] $csv = "false")
+
+Import-Module C:\Windows\system32\WindowsPowerShell\v1.0\Modules\DataOnTap
+
+$passwd = ConvertTo-SecureString $password -AsPlainText -Force
+$cred = New-Object -typename System.Management.Automation.PSCredential -ArgumentList $user, $passwd
+$nctlr = Connect-NcController $server -Credential $cred
+$nodesinfo = @{}
+
+#Get export policies and export to a file
+if ($csv -eq "false") {
+    Get-NcExportPolicy -Controller $nctlr -VserverContext $vserver | Export-Clixml $exportPolicyFile
+} else {
+    Get-NcExportPolicy -Controller $nctlr -VserverContext $vserver | Export-Csv $exportPolicyFile
+}
+
+#Display Exports
+if ($spit -ne "none")
+{
+    echo "`n************************EXPORT POLICIES START*****************************************"
+    if ($spit -eq "more")
+    {
+        Import-Clixml $exportPolicyFile | Format-List
+    }
+    else
+    {
+        Import-Clixml $exportPolicyFile
+    }
+    echo "************************EXPORT POLICIES END*****************************************`n"
+
+}
+
+#Get nfs protocol export rules and output to a file
+if ($csv -eq "false") {
+    Get-NcExportRule -Controller $nctlr -VserverContext $vserver | Export-Clixml $exportRuleFile
+} else {
+    Get-NcExportRule -Controller $nctlr -VserverContext $vserver | Export-Csv $exportRuleFile
+}
+
+#Display protocol Export rules
+if ($spit -ne "none")
+{
+    echo "`n************************EXPORT RULES START*****************************************"
+    if ($spit -eq "more")
+    {
+        Import-Clixml $exportRuleFile | Format-List
+    }
+    else
+    {
+        Import-Clixml $exportRuleFile
+    }
+    echo "************************EXPORT RULES END*****************************************`n"
+
+}

--- a/backupSharesAcls.ps1
+++ b/backupSharesAcls.ps1
@@ -10,6 +10,9 @@
 #
 # 3. If you want to save only shares that start with "test" and share1 on vserver vs2.
 # Run as: .\backupSharesAcls.ps1 -server 10.53.33.59 -user admin -password netapp1! -vserver vs2 -share "test* | share1" -shareFile C:\share.xml -aclFile C:\acl.xml -spit more
+#
+# 4. If you want to save shares and ACLs into .csv format for examination.
+# Run as: .\backupSharesAcls.ps1 -server 10.53.33.59 -user admin -password netapp1! -vserver vs2 -share *  -shareFile C:\shares.csv -aclFile C:\acl.csv -csv true -spit more
 
 Param([parameter(Mandatory = $true)] [alias("s")] $server,
       [parameter(Mandatory = $true)] [alias("u")] $user,
@@ -18,7 +21,8 @@ Param([parameter(Mandatory = $true)] [alias("s")] $server,
       [parameter(Mandatory = $true)] [alias("sh")] $share,
       [parameter(Mandatory = $true)] [alias("sf")] $shareFile,
       [parameter(Mandatory = $true)] [alias("af")] $aclFile,
-      [parameter(Mandatory = $true)] [alias("sp")] [Validateset("none","less","more")] $spit)
+      [parameter(Mandatory = $true)] [alias("sp")] [Validateset("none","less","more")] $spit,
+      [Validateset("false","true")] $csv = "false")
 
 Import-Module C:\Windows\system32\WindowsPowerShell\v1.0\Modules\DataONTAP
 
@@ -28,10 +32,19 @@ $nctlr = Connect-NcController $server -Credential $cred
 $nodesinfo = @{}
 
 #Get all the shares and export to file
-Get-NcCifsShare -Controller $nctlr -VserverContext $vserver -Name $share | Export-Clixml $shareFile
+if ($csv -eq "false") {
+    Get-NcCifsShare -Controller $nctlr -VserverContext $vserver -Name $share | Export-Clixml $shareFile
+} else {
+    Get-NcCifsShare -Controller $nctlr -VserverContext $vserver -Name $share | Export-Csv $shareFile
+}
+
 
 #Get all the acls and export to file
-Get-NcCifsShareAcl -Controller $nctlr -VserverContext $vserver -Share $share | Export-Clixml $aclFile
+if ($csv -eq "false") {
+    Get-NcCifsShareAcl -Controller $nctlr -VserverContext $vserver -Name $share | Export-Clixml $shareFile
+} else {
+    Get-NcCifsShareAcl -Controller $nctlr -VserverContext $vserver -Name $share | Export-Csv $shareFile
+}
 
 #Display Shares and Acls saved
 if ($spit -ne "none")

--- a/restoreExportPolicyRules.ps1
+++ b/restoreExportPolicyRules.ps1
@@ -1,0 +1,197 @@
+# Usage:
+# Run as: .\restoreExportPolicyRules.ps1 -server <mgmt_ip> -user <mgmt_user> -password <mgmt_user_password> -vserver <vserver name> -exportPolicyFile <xml file to get exports from > -exportRuleFile <xml file to get export rules from> -spit <none,less,more depending on info to print> 
+#
+# Example
+# 1. If you want to save create back exports from xml file C:\export.xml and acls from xml file C:\acls.xml on vserver vs2, with less information displayed on the screen 
+# Run as:  .\restoreExportPolicyRules.ps1 -server 10.53.33.59 -user admin -password netapp1! -vserver vs2 -exportPolicyFile C:\export.xml -exportRuleFile C:\rules.xml -spit less 
+#
+# 2. If you only want to print the commands and not actually create the exports, use -printOnly 
+# Run as:  .\restoreExportPolicyRules.ps1 -s 10.53.33.59 -u admin -p netapp1! -v vs2 -ep C:\export.xml -er C:\acl.xml -dp less -po true
+
+Param([parameter(Mandatory = $true)] [alias("s")] $server,
+      [parameter(Mandatory = $true)] [alias("u")] $user,
+      [parameter(Mandatory = $true)] [alias("p")] $password,
+      [parameter(Mandatory = $true)] [alias("v")] $vserver,
+      [parameter(Mandatory = $true)] [alias("ep")] $exportPolicyFile,
+      [parameter(Mandatory = $true)] [alias("er")] $exportRuleFile,
+      [parameter(Mandatory = $true)] [alias("sp")] [Validateset("none","less","more")]$spit,
+      [alias("po")] [Validateset("false","true")] $printOnly = "false")
+            
+Import-Module C:\Windows\system32\WindowsPowerShell\v1.0\Modules\DataOnTap
+
+$passwd = ConvertTo-SecureString $password -AsPlainText -Force
+$cred = New-Object -typename System.Management.Automation.PSCredential -ArgumentList $user, $passwd
+$nctlr = Connect-NcController $server -Credential $cred
+$nodesinfo = @{}
+
+$new_policies = Import-Clixml -Path $exportPolicyFile
+
+if ($spit -ne "none")
+{
+    echo "====================================================================================="
+    echo "EXPORT POLICIES"
+    echo "====================================================================================="
+
+    if ($spit -eq "less")
+    {
+        $new_policies
+    } 
+    elseif ($spit -eq "more")
+    {
+        $new_policies | Format-List
+    }
+}
+echo "====================================================================================="
+
+$new_policies | foreach { 
+   $mycmd = "New-NcExportPolicy -VserverContext $vserver"
+
+   $myPolicyName = $_.PolicyName
+   
+
+    if (($myPolicyName -ne $null) -and ($myPolicyName -ne ""))
+    {
+        $mycmd = $mycmd + " -Name ""$myPolicyName"""          
+    }
+
+    if ($myPolicyName -eq "default") { $mycmd = "" } # don't create default export policy
+
+
+    if ($spit -ne "none")
+    {
+        $mycmd
+        echo "--------------------"
+    }
+
+    if (($printOnly -eq "false") -and ($myPolicyName -ne "default"))
+    {
+        Invoke-Expression $mycmd
+    }
+}
+
+$new_rules = Import-Clixml -Path $exportRuleFile
+
+if ($spit -ne "none")
+{
+    echo "====================================================================================="
+    echo "EXPORT RULES"
+    echo "====================================================================================="
+
+    if ($spit -eq "less")
+    {
+        $new_rules
+    } 
+    elseif ($spit -eq "more")
+    {
+        $new_rules | Format-List
+    }
+}
+echo "====================================================================================="
+
+$new_rules | foreach { 
+   $mycmd = "New-NcExportRule -VserverContext $vserver"
+
+
+    if (($myPolicyName -ne $null) -and ($myPolicyName -ne ""))
+    {
+        $mycmd = $mycmd + " -Policy ""$myPolicyName"""          
+    }
+
+   $myRuleIndex = $_.RuleIndex
+   
+    if (($myRuleIndex -ne $null) -and ($myruleIndex -ne ""))
+    {
+        $mycmd = $mycmd + " -Index $myRuleIndex"          
+    }
+
+   $myProtocol = $_.Protocol
+   
+    if (($myProtocol -ne $null) -and ($myruleProtocol -ne ""))
+    {
+        $mycmd = $mycmd + " -Protocol ""$myProtocol"""          
+    }
+
+   $myClientMatch = $_.ClientMatch
+   
+    if (($myClientMatch -ne $null) -and ($myClientMatch -ne ""))
+    {
+        $mycmd = $mycmd + " -ClientMatch ""$myClientMatch"""          
+    }
+
+   $myAnonymousUserID = $_.AnonymousUserId
+   
+    if (($myAnonymousUserId -ne $null) -and ($myAnonymousUserId -ne ""))
+    {
+        $mycmd = $mycmd + " -Anon ""$myAnonymousUserId"""          
+    }
+
+   $myRoRule = $_.RoRule
+   
+    if (($myRoRule -ne $null) -and ($myRoRule -ne ""))
+    {
+        $mycmd = $mycmd + " -ReadOnlySecurityFlavor ""$myRoRule"""          
+    }
+
+   $myRwRule = $_.RwRule
+   
+    if (($myRwRule -ne $null) -and ($myRwRule -ne ""))
+    {
+        $mycmd = $mycmd + " -ReadWriteSecurityFlavor ""$myRwRule"""          
+    }
+
+   $mySuperUserSecurity = $_.SuperUserSecurity
+   
+    if (($mySuperUserSecurity -ne $null) -and ($mySuperUserSecurity -ne ""))
+    {
+        $mycmd = $mycmd + " -SuperUserSecurityFlavor ""$mySuperUserSecurity"""          
+    }
+
+   $myExportChownMode = $_.ExportChownMode
+   
+    if (($myExportChownMode -ne $null) -and ($myExportChownMode -ne ""))
+    {
+        $mycmd = $mycmd + " -ChownMode ""$myExportChownMode"""          
+    }
+
+   $myExportNtfsUnixSecurityOps = $_.ExportNtfsUnixSecurityOps
+   
+    if (($myExportNtfsUnixSecurityOps -ne $null) -and ($myExportNtfsUnixSecurityOps -ne ""))
+    {
+        $mycmd = $mycmd + " -NtfsUnixSecurityOps ""$myExportNtfsUnixSecurityOps"""          
+    }
+
+    $myIsAllowDevIsEnabled = $_.IsAllowDevIsEnabled
+
+    if (($myIsAllowDevIsEnabled))
+    {
+        $mycmd = $mycmd + " -EnableDev"
+    } 
+    else 
+    {
+	$mycmd = $mycmd + " -DisableDev"
+    }
+    
+    $myIsAllowSetUidEnabled = $_.IsAllowSetUidEnabled
+
+    if (($myIsAllowSetUidEnabled))
+    {
+        $mycmd = $mycmd + " -EnableSetUid"
+    } 
+    else 
+    {
+	$mycmd = $mycmd + " -DisableSetUid"
+    }
+    
+
+    if ($spit -ne "none")
+    {
+        $mycmd
+        echo "--------------------"
+    }
+
+    if ($printOnly -eq "false")
+    {
+        Invoke-Expression $mycmd
+    }
+}
+


### PR DESCRIPTION
1) added a -csv parameter to the `backupSharesAcls.ps1` to allow examination of the files by users in a more human readable format.  
2) created two new scripts to capture export policies and rules. Blog post forthcoming on scottharney.com showing example use . also include the -csv parameter here
