### PR TITLE
Fixed issue with multiple symlink properties

### DIFF
--- a/restoreSharesAcls.ps1
+++ b/restoreSharesAcls.ps1
@@ -113,8 +113,10 @@ $new_shares | foreach {
             {
                 $mySymlinkProp = $mySymlinkProp , $prop -join ','
             }
-        }    
-        $mycmd = $mycmd + " -SymlinkProperties ""$mySymlinkProp"""          
+        }
+# Double double quotes break Add-NcCifsShare when having multiple symlink
+# properties. Tested with PS toolkit 4.7 againt 9.3P8    
+        $mycmd = $mycmd + " -SymlinkProperties $mySymlinkProp"          
     } 
 
     $myFileUmask = $_.FileUmask


### PR DESCRIPTION
Hi

I ran into a small error while restoring a share with multiple symlink properties. See the output below for a quick test of my fix.

Hope that helps.

Best regards
Roger

Backing up a share with the following attributes:

vserver        share-name           symlink-properties 
-------------- -------------------- ------------------ 
svm_01 vol_share_copy_test$ enable,read_only

PS D:\Scripts\NetApp\orig\cDOT-CIFS-share-backup-restore> .\backupSharesAcls.ps1 -server toaster -user admin -password  -spit less -share vol_share_copy_test$ -vserver svm_01 -shareFile C:\Temp \share.xml -aclFile c:\temp\acl.xml

************************SHARES START*****************************************

CifsServer                ShareName       Path                                Comment
----------                ---------       ----                                -------
NAS-HAM-CH-052            vol_share_co... /vol_share_copy_test                TEST123
************************SHARES END*****************************************

************************ACLS START*****************************************

NcController    : toaster
Permission      : full_control
Share           : vol_share_copy_test$
Unixid          :
UserGroupType   : windows
UserOrGroup     : Everyone
Vserver         : svm_01
Winsid          : S-1-1-0
UnixidSpecified : False

************************ACLS END*****************************************


PS D:\Scripts\NetApp\orig\cDOT-CIFS-share-backup-restore>

Restore the share:

PS D:\Scripts\NetApp\orig\cDOT-CIFS-share-backup-restore> .\restoreSharesAcls.ps1 -server toaster -user admin -vserver svm_01 -shareFile c:\temp\share.xml -aclFile c:\temp\acl.xml  -password  -spit less
=====================================================================================
SHARES
=====================================================================================

CifsServer                ShareName       Path                                Comment
----------                ---------       ----                                -------
NAS-HAM-CH-052            vol_share_co... /vol_share_copy_test                TEST123
=====================================================================================
Add-NcCifsShare -VserverContext svm_01 -Name "vol_share_copy_test$" -Path "/vol_share_copy_test" -Comment "TEST
123" -ShareProperties browsable,changenotify,oplocks,show_previous_versions -SymlinkProperties "enable,read_only" -Offl
ineFilesMode "manual"
--------------------
Add-NcCifsShare : Invalid value specified for "symlink-properties" element within "cifs-share-create":
"enable,read_only".
At line:1 char:1
+ Add-NcCifsShare -VserverContext svm_01 -Name "vol_share_copy_test$" -Pat ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (toaster:NcController) [Add-NcCifsShare], EINVALIDINPUTERROR
    + FullyQualifiedErrorId : ApiException,DataONTAP.C.PowerShell.SDK.Cmdlets.Cifs.AddNcCifsShare

Remove-NcCifsShareAcl : entry doesn't exist
At D:\Scripts\NetApp\orig\cDOT-CIFS-share-backup-restore\restoreSharesAcls.ps1:159 char:9
+         Remove-NcCifsShareAcl -VserverContext $vserver -Share $myName -UserOrGro ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (toaster:NcController) [Remove-NcCifsShareAcl], EOBJECTNOTFOUND
    + FullyQualifiedErrorId : ApiException,DataONTAP.C.PowerShell.SDK.Cmdlets.Cifs.RemoveNcCifsShareAcl

=====================================================================================
ACLS
=====================================================================================

NcController    : toaster
Permission      : full_control
Share           : vol_share_copy_test$
Unixid          :
UserGroupType   : windows
UserOrGroup     : Everyone
Vserver         : svm_01
Winsid          : S-1-1-0
UnixidSpecified : False

=====================================================================================
Add-NcCifsShareAcl -VserverContext svm_01 -Share "vol_share_copy_test$" -UserGroupType "windows" -UserOrGroup "
Everyone" -Permission "full_control"
--------------------
Add-NcCifsShareAcl : The share vol_share_copy_test$ does not exist
At line:1 char:1
+ Add-NcCifsShareAcl -VserverContext svm_01 -Share "vol_share_copy_test$"  ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (toaster:NcController) [Add-NcCifsShareAcl], EAPIERROR
    + FullyQualifiedErrorId : ApiException,DataONTAP.C.PowerShell.SDK.Cmdlets.Cifs.AddNcCifsShareAcl

Restore with fix:

PS D:\Scripts\NetApp\cDOT-CIFS-share-backup-restore> .\restoreSharesAcls.ps1 -server toaster -user admin -vserver svm_01 -shareFile c:\temp\share.xml -aclFile c:\temp\acl.xml  -password  -spit less
=====================================================================================
SHARES
=====================================================================================

CifsServer                ShareName       Path                                Comment
----------                ---------       ----                                -------
NAS-HAM-CH-052            vol_share_co... /vol_share_copy_test                TEST123
=====================================================================================
Add-NcCifsShare -VserverContext svm_01 -Name "vol_share_copy_test$" -Path "/vol_share_copy_test" -Comment "TEST
123" -ShareProperties browsable,changenotify,oplocks,show_previous_versions -SymlinkProperties enable,read_only -Offlin
eFilesMode "manual"
--------------------
NAS-HAM-CH-052            vol_share_co... /vol_share_copy_test                TEST123
=====================================================================================
ACLS
=====================================================================================

NcController    : toaster
Permission      : full_control
Share           : vol_share_copy_test$
Unixid          :
UserGroupType   : windows
UserOrGroup     : Everyone
Vserver         : svm_01
Winsid          : S-1-1-0
UnixidSpecified : False

=====================================================================================
Add-NcCifsShareAcl -VserverContext svm_01 -Share "vol_share_copy_test$" -UserGroupType "windows" -UserOrGroup "
Everyone" -Permission "full_control"
--------------------

NcController    : toaster
Permission      : full_control
Share           : vol_share_copy_test$
Unixid          :
UserGroupType   : windows
UserOrGroup     : Everyone
Vserver         : svm_01
Winsid          : S-1-1-0
UnixidSpecified : False


